### PR TITLE
Enabling sourcemap generation for Typescript files

### DIFF
--- a/generators/app/templates/gulp_tasks/scripts.js
+++ b/generators/app/templates/gulp_tasks/scripts.js
@@ -3,6 +3,7 @@ const gulp = require('gulp');
 const babel = require('gulp-babel');
 <% } -%>
 <% if (js === 'typescript') { -%>
+const sourcemaps = require('gulp-sourcemaps');
 const typescript = require('gulp-typescript');
 const tsConf = require('../tsconfig.json').compilerOptions;
 <% } -%>
@@ -16,7 +17,9 @@ function scripts() {
     .pipe(babel())
 <% } -%>
 <% if (js === 'typescript') { -%>
+    .pipe(sourcemaps.init())
     .pipe(typescript(tsConf))
+    .pipe(sourcemaps.write('./sourcemaps'))
 <% } -%>
     .pipe(gulp.dest(conf.path.tmp()));
 }


### PR DESCRIPTION
gulp-typescript doesn't suport sourcemaps. they asked useing gulp-sourcemaps instead.
https://github.com/ivogabe/gulp-typescript